### PR TITLE
Prevent NPE for recovery notification

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,8 +148,13 @@ node('lisk-nano-01'){
       }
       milestone 1
       /* notify of success if previous build failed */
-      if (currentBuild.getPreviousBuild().result == 'FAILURE') {
-        slackSend color: 'good', message: "Recovery: build #${env.BUILD_NUMBER} of <${env.BUILD_URL}|${env.JOB_NAME}> was sucessful.", channel: '#lisk-nano-jenkins'
+      previous_build = currentBuild.getPreviousBuild()
+      if (previous_build != null && previous_build.result == 'FAILURE') {
+        def pr_branch = ''
+        if (env.CHANGE_BRANCH != null) {
+          pr_branch = " (${env.CHANGE_BRANCH})"
+        }
+        slackSend color: 'good', message: "Recovery: build #${env.BUILD_NUMBER} of <${env.BUILD_URL}|${env.JOB_NAME}>${pr_branch} was successful.", channel: '#lisk-nano-jenkins'
       }
     }
   }


### PR DESCRIPTION
- check if there is a previous build before trying to find out its result
- add PR branch name to the recovery notification